### PR TITLE
Add Fireflies.ai promo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # aicompares
+
+This repository hosts a simple promotional page for [Fireflies.ai](https://fireflies.ai/?fpr=logan40). The page highlights key features and includes a call-to-action link using the marketing referral.
+
+To view the page locally, open `index.html` in your browser. To host it on GitHub Pages, enable Pages in the repository settings and select the main branch as the source.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8' />
+  <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+  <title>Fireflies.ai – Your Meeting Notes Assistant</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      line-height: 1.6;
+      margin: 0;
+      padding: 0;
+      background: #f7f7f7;
+    }
+    header {
+      background: #673ab7;
+      color: #fff;
+      padding: 20px;
+      text-align: center;
+    }
+    section {
+      max-width: 800px;
+      margin: 40px auto;
+      padding: 0 20px;
+      background: #fff;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    h1 {
+      margin-top: 0;
+    }
+    .cta {
+      display: block;
+      margin: 20px auto;
+      width: fit-content;
+      padding: 10px 20px;
+      background: #ff7043;
+      color: #fff;
+      text-decoration: none;
+      border-radius: 4px;
+      font-weight: bold;
+    }
+    footer {
+      text-align: center;
+      margin-top: 40px;
+      padding: 20px;
+      font-size: 0.9em;
+      color: #555;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Boost Your Productivity with Fireflies.ai</h1>
+    <p>Automatic note-taking and meeting insights powered by AI</p>
+  </header>
+
+  <section>
+    <h2>Why Fireflies.ai?</h2>
+    <ul>
+      <li>Transcribe meetings across major video-conferencing platforms.</li>
+      <li>Search and share meeting insights with your team instantly.</li>
+      <li>Stay focused on the conversation while Fireflies takes notes.</li>
+    </ul>
+    <a class='cta' href='https://fireflies.ai/?fpr=logan40' target='_blank' rel='noopener noreferrer'>Try Fireflies.ai Now</a>
+  </section>
+
+  <footer>
+    <p>Promotion powered by <a href='https://fireflies.ai/?fpr=logan40' target='_blank' rel='noopener noreferrer'>Fireflies.ai</a>.</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `index.html` landing page promoting Fireflies.ai with referral link.
- Update README with instructions for viewing the page and enabling GitHub Pages.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974fb91db8833389d41facd01cbd52